### PR TITLE
feat: bootstrap dashboard with mock landing

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_USE_MOCK=true

--- a/app/_providers.tsx
+++ b/app/_providers.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_USE_MOCK === "true") {
+      import("../mocks/browser").then(({ worker }) => {
+        worker.start();
+      });
+    }
+  }, []);
+
+  return <>{children}</>;
+}
+
+export default Providers;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./_providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Banner from "../components/Banner";
+import KpiCard from "../components/KpiCard";
+import { getKpi } from "../lib/api";
+
+interface Kpi {
+  title: string;
+  value: string | number;
+}
+
+export default function Page() {
+  const [kpis, setKpis] = useState<Kpi[]>([]);
+
+  useEffect(() => {
+    getKpi().then(setKpis).catch(console.error);
+  }, []);
+
+  return (
+    <main className="space-y-6 p-6">
+      <Banner />
+      <div className="grid gap-4 sm:grid-cols-3">
+        {kpis.slice(0, 3).map((kpi) => (
+          <KpiCard key={kpi.title} title={kpi.title} value={kpi.value} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function Banner() {
+  return (
+    <div className="rounded-md bg-blue-50 p-4 text-blue-800">
+      Welcome to ColdExperience Dashboard
+    </div>
+  );
+}

--- a/components/KpiCard.tsx
+++ b/components/KpiCard.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  title: string;
+  value: string | number;
+}
+
+export default function KpiCard({ title, value }: Props) {
+  return (
+    <div className="rounded-lg border p-4 shadow-sm">
+      <p className="text-sm text-gray-500">{title}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/data/economy.json
+++ b/data/economy.json
@@ -1,0 +1,4 @@
+{
+  "totalRevenue": 5432,
+  "outstanding": 1200
+}

--- a/data/kpi.json
+++ b/data/kpi.json
@@ -1,0 +1,5 @@
+[
+  { "title": "Bookings", "value": 128 },
+  { "title": "Revenue", "value": 5432 },
+  { "title": "Customers", "value": 321 }
+]

--- a/data/notifications.json
+++ b/data/notifications.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "message": "New booking received" },
+  { "id": 2, "message": "Payment pending" }
+]

--- a/data/slots.json
+++ b/data/slots.json
@@ -1,0 +1,6 @@
+{
+  "slots": [
+    { "id": 1, "time": "10:00", "booked": true },
+    { "id": 2, "time": "11:00", "booked": false }
+  ]
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,10 @@
+const fetcher = async (url: string, options?: RequestInit) => {
+  const res = await fetch(url, options);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json();
+};
+
+export const getKpi = () => fetcher("/api/kpi");
+export const getNotifications = () => fetcher("/api/notifications");
+export const getEconomy = () => fetcher("/api/economy/summary");
+export const getToday = () => fetcher("/api/today");

--- a/mocks/browser.ts
+++ b/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,0 +1,15 @@
+import { http, HttpResponse } from "msw";
+import kpi from "../data/kpi.json";
+import notifications from "../data/notifications.json";
+import economy from "../data/economy.json";
+import today from "../data/slots.json";
+
+export const handlers = [
+  http.get("/api/kpi", () => HttpResponse.json(kpi)),
+  http.get("/api/notifications", () => HttpResponse.json(notifications)),
+  http.get("/api/economy/summary", () => HttpResponse.json(economy)),
+  http.get("/api/today", () => HttpResponse.json(today)),
+  http.post("/api/bookings/:id/mark-paid", ({ params }) =>
+    HttpResponse.json({ success: true, id: params.id })
+  ),
+];

--- a/package.json
+++ b/package.json
@@ -3,34 +3,33 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "postinstall": "msw init public/ --save --no-open || true"
   },
   "dependencies": {
-    "name": "ColdExperience-Dashboard",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",
     "msw": "^2.11.1",
-    "next": "15.5.2",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
     "@types/node": "^20.19.13",
-    "@types/react": "^19.1.12",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.5.2",
-    "tailwindcss": "^4",
-    "tw-animate-css": "^1.3.8",
-    "typescript": "^5"
+    "@types/react": "^18.2.17",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.15",
+    "eslint": "^8",
+    "eslint-config-next": "^14.0.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.3.3"
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,1 @@
+// Placeholder service worker for MSW

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,9 +2,9 @@ import type { Config } from 'tailwindcss'
 
 const config: Config = {
   content: [
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './lib/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- setup Next.js 14 project with Tailwind, MSW, and mock data
- add providers to boot MSW in development
- create landing page with banner and KPI cards

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: next not found, missing deps)
- `npm install` (fails: 403 Forbidden while fetching dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68bd5d6cd3e0832c842544c9d771b2ef